### PR TITLE
fix(deps): bump vite 6.4.2->6.4.3 in client (GHSA-fx2h-pf6j-xcff)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "client",
-  "version": "0.1.0",
-  "description": "",
-  "type": "module",
-  "scripts": {
-    "start": "vite",
-    "dev": "vite",
-    "build": "vite build",
-    "typecheck": "tsc --noEmit",
-    "lighthouse": "lhci autorun --config=./lighthouserc.cjs",
-    "serve": "vite preview",
-    "tauri": "tauri"
-  },
-  "license": "MIT",
-  "dependencies": {
-    "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-dialog": "^2.6.0",
-    "@tauri-apps/plugin-opener": "^2",
-    "@tauri-apps/plugin-shell": "^2.3.5",
-    "solid-js": "^1.9.3"
-  },
-  "devDependencies": {
-    "@lhci/cli": "^0.15.1",
-    "@tailwindcss/vite": "^4.1.18",
-    "@tauri-apps/cli": "^2",
-    "rollup": "^4.59.0",
-    "tailwindcss": "^4.1.18",
-    "typescript": "~5.6.2",
-    "vite": "^6.4.2",
-    "vite-plugin-solid": "^2.11.0"
-  }
+	"name": "client",
+	"version": "0.1.0",
+	"description": "",
+	"type": "module",
+	"scripts": {
+		"start": "vite",
+		"dev": "vite",
+		"build": "vite build",
+		"typecheck": "tsc --noEmit",
+		"lighthouse": "lhci autorun --config=./lighthouserc.cjs",
+		"serve": "vite preview",
+		"tauri": "tauri"
+	},
+	"license": "MIT",
+	"dependencies": {
+		"@tauri-apps/api": "^2",
+		"@tauri-apps/plugin-dialog": "^2.6.0",
+		"@tauri-apps/plugin-opener": "^2",
+		"@tauri-apps/plugin-shell": "^2.3.5",
+		"solid-js": "^1.9.3"
+	},
+	"devDependencies": {
+		"@lhci/cli": "^0.15.1",
+		"@tailwindcss/vite": "^4.1.18",
+		"@tauri-apps/cli": "^2",
+		"rollup": "^4.59.0",
+		"tailwindcss": "^4.1.18",
+		"typescript": "~5.6.2",
+		"vite": "^6.4.3",
+		"vite-plugin-solid": "^2.11.0"
+	}
 }

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 0.15.1
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.18(vite@6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.0
@@ -43,11 +43,11 @@ importers:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
-        specifier: ^6.4.2
-        version: 6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
+        specifier: ^6.4.3
+        version: 6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
       vite-plugin-solid:
         specifier: ^2.11.0
-        version: 2.11.10(solid-js@1.9.11)(vite@6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 2.11.10(solid-js@1.9.11)(vite@6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))
 
 packages:
 
@@ -1939,8 +1939,8 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
-  vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -2545,12 +2545,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@tailwindcss/vite@4.1.18(vite@6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -3949,7 +3949,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)):
+  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -3957,12 +3957,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.11
       solid-refresh: 0.6.3(solid-js@1.9.11)
-      vite: 6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
-      vitefu: 1.1.1(vite@6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      vite: 6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitefu: 1.1.1(vite@6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3976,9 +3976,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
-  vitefu@1.1.1(vite@6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)):
+  vitefu@1.1.1(vite@6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.3(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)
 
   webdriver-bidi-protocol@0.4.1: {}
 


### PR DESCRIPTION
## Summary

Bumps vite from 6.4.2 to 6.4.3 in client/ to patch GHSA-fx2h-pf6j-xcff (Windows dev-server path traversal via /@fs/ URLs). This advisory is Windows dev-server only — no production impact.

## Changes

| Package | Before | After |
|---|---|---|
| vite | 6.4.2 | 6.4.3 |

## Gate result

pnpm exec tsc --noEmit passed (exit 0).