### PR TITLE
ci: pin Go toolchain to 1.25.12 (GO-2026-5856 / CVE-2026-42505)

### DIFF
--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - uses: dtolnay/rust-toolchain@stable
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
       - uses: dtolnay/rust-toolchain@stable
       - uses: pnpm/action-setup@v6
         with:
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
       - name: Run Go tests
         run: cd server && go test -race ./...
 


### PR DESCRIPTION
main has been red since d972767. The break is not in our code: the verify
contract's G3 gate runs govulncheck, and the pinned Go toolchain (1.25.11)
carries a standard-library vulnerability.

  GO-2026-5856 / CVE-2026-42505  crypto/tls
    Handshakes using Encrypted Client Hello could be de-anonymized by a
    passive network observer, because pre-shared key identities were
    disclosed in the unencrypted client hello.
    Found in:  crypto/tls@go1.25.11
    Fixed in:  go1.25.12 (also go1.26.5, go1.27.0-rc.2)

govulncheck reported it as reachable, not merely present:
  main.go:35:31   server.main calls http.ListenAndServe -> tls.Conn.HandshakeContext
  handler.go:7:2  server.init calls http.init          -> tls.Conn.Read

Minimal fix: bump the three pinned toolchain versions from 1.25.11 to
1.25.12, staying on the 1.25 release branch. 1.25.12 is a currently
supported stable release (go.dev/dl lists exactly go1.26.5 and go1.25.12).
Moving to 1.26.x is a larger change and is deliberately not bundled here.

  .github/workflows/test-build-release.yml  (2 pins)
  .github/workflows/nightly-full-sweep.yml  (1 pin)

Verification note: this cannot be verified locally. The failure is a
property of the CI-pinned toolchain, and this machine runs go1.26.5, which
is already patched -- a local govulncheck passes either way and proves
nothing. CI is the gate.
