### PR TITLE
chore(git): land the consolidated guard scripts

### DIFF
--- a/scripts/git/create-branch.sh
+++ b/scripts/git/create-branch.sh
@@ -2,17 +2,72 @@
 set -euo pipefail
 
 # codex-os-managed
-if [[ $# -lt 2 ]]; then
-  echo "usage: $0 <type> <task description>"
-  exit 2
+#
+# Promoted from AssistSupport, which was the only repository whose version
+# validated the branch type, bounded the slug, and reused an existing branch
+# instead of failing. The one thing changed on the way up is the base: that
+# version hardcoded origin/master, which is right for AssistSupport and wrong
+# for most of the portfolio, so the default branch is resolved instead.
+#
+# Usage: create-branch.sh "task summary" [type] [base]
+
+task="${1:-}"
+kind="${2:-feat}"
+base="${3:-}"
+
+types='feat|fix|chore|refactor|docs|test|perf|ci|spike|hotfix'
+
+if [[ -z "$task" ]]; then
+  echo "Usage: $0 \"task summary\" [${types//|/|}] [base]"
+  exit 1
 fi
 
-branch_type="$1"
-shift
+if ! [[ "$kind" =~ ^($types)$ ]]; then
+  echo "Invalid branch type: $kind"
+  echo "Expected one of: ${types//|/, }"
+  exit 1
+fi
 
-task="$*"
-slug="$(echo "$task" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g; s/-+/-/g')"
-branch="codex/${branch_type}/${slug}"
+# Resolve the base branch rather than assuming a name. origin/HEAD is the
+# repository's own answer; the named fallbacks cover a clone that never fetched
+# it, and the final fallback is the current commit, which always exists.
+resolve_base() {
+  local ref
+  if ref="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+    echo "$ref"
+    return
+  fi
+  for ref in origin/main origin/master main master; do
+    if git rev-parse --verify --quiet "$ref" >/dev/null; then
+      echo "$ref"
+      return
+    fi
+  done
+  echo "HEAD"
+}
 
-git switch -c "$branch"
-echo "$branch"
+# A branch name is a path, so an unbounded slug can exceed the filesystem's
+# limit on a single component and fail at checkout rather than at validation.
+slug="$(echo "$task" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+slug="${slug:0:48}"
+slug="${slug%-}"
+
+if [[ -z "$slug" ]]; then
+  echo "Task summary produced an empty slug: $task"
+  exit 1
+fi
+
+branch="codex/${kind}/${slug}"
+
+git fetch origin --quiet 2>/dev/null || true
+[[ -n "$base" ]] || base="$(resolve_base)"
+
+# Reusing the branch when it already exists is the difference between resuming
+# a task and getting a fatal error partway through one.
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  git checkout --quiet "$branch"
+  echo "Resumed branch: $branch"
+else
+  git checkout --quiet -b "$branch" "$base"
+  echo "Created branch: $branch (from $base)"
+fi

--- a/scripts/git/guard-atomic.sh
+++ b/scripts/git/guard-atomic.sh
@@ -2,15 +2,29 @@
 set -euo pipefail
 
 # codex-os-managed
+#
+# An intentional exception has to be expressible. Without one, the only way past
+# this guard is to bypass the hook that runs it, which switches off the branch,
+# generated-file, large-file and secret guards at the same time. AssistSupport
+# was the only repository in the portfolio carrying this escape hatch.
+if [[ "${GIT_GUARD_ALLOW_LARGE_COMMIT:-0}" == "1" ]]; then
+  echo "Atomicity check skipped: GIT_GUARD_ALLOW_LARGE_COMMIT=1."
+  exit 0
+fi
+
 max_files="${GIT_GUARD_MAX_FILES:-25}"
 count="$(git diff --cached --name-only | sed '/^$/d' | wc -l | tr -d ' ')"
 
-if (( count == 0 )); then
+if ((count == 0)); then
   echo "No staged files; skipping atomicity check."
   exit 0
 fi
 
-if (( count > max_files )); then
+# Deletions are counted deliberately. Removing forty files is a large commit
+# whichever direction the change runs, and the escape hatch above is how to say
+# that it is intentional.
+if ((count > max_files)); then
   echo "Too many staged files ($count > $max_files). Split into atomic commits."
+  echo "For a deliberately large commit, set GIT_GUARD_ALLOW_LARGE_COMMIT=1."
   exit 1
 fi

--- a/scripts/git/guard-branch.sh
+++ b/scripts/git/guard-branch.sh
@@ -2,45 +2,75 @@
 set -euo pipefail
 
 # codex-os-managed
-branch="$(git rev-parse --abbrev-ref HEAD)"
-pattern='^(codex/)?(feat|fix|chore|refactor|docs|test|perf|ci|spike|hotfix)/[a-z0-9]+(-[a-z0-9]+)*$'
+#
+# Consolidated from the ten variants this script had drifted into across the
+# portfolio. Every rule below already existed in at least one of them; none is
+# new. scripts/git/tests/test-guard-branch.sh pins each one.
+#
+# Accepted branch shapes:
+#   <type>/<slug>          fix/null-pointer
+#   codex/<type>/<slug>    codex/fix/null-pointer
+#   <agent>/<task-slug>    cc/rebuild-index, for peer agents
 
-if [[ "${CI:-}" == "true" || -n "${GITHUB_ACTIONS:-}" ]]; then
+typed_pattern='^(codex/)?(feat|fix|chore|refactor|docs|test|perf|ci|spike|hotfix)/[a-z0-9]+(-[a-z0-9]+)*$'
+peer_pattern='^(codex|cc)/[a-z0-9]+(-[a-z0-9]+)+$'
+
+in_ci() { [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; }
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# A CI checkout is usually detached, so the real branch name lives in the event
+# environment rather than in HEAD. GITHUB_REF_NAME also carries tag names, so
+# it is trusted only when the ref really is a branch. Outside CI these
+# variables are ignored entirely: a stray value in a local shell should not be
+# able to talk this guard into approving a name that is not checked out.
+if in_ci; then
   if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
-    branch="${GITHUB_HEAD_REF}"
-  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
-    branch="${GITHUB_REF_NAME}"
+    branch="$GITHUB_HEAD_REF"
+  elif [[ "${GITHUB_REF_TYPE:-branch}" == "branch" && -n "${GITHUB_REF_NAME:-}" ]]; then
+    branch="$GITHUB_REF_NAME"
   fi
 fi
 
 if [[ "$branch" == "HEAD" ]]; then
-  if [[ "${CI:-}" == "true" || -n "${GITHUB_ACTIONS:-}" ]]; then
-    echo "Detached HEAD in CI; skipping local branch-name enforcement."
+  if in_ci; then
+    echo "Detached HEAD in CI; skipping branch-name enforcement."
     exit 0
   fi
   echo "Detached HEAD is not allowed for local development."
-  echo "Checkout a <type>/<slug> or codex/<type>/<slug> branch."
+  echo "Check out a <type>/<slug> or codex/<type>/<slug> branch."
   exit 1
 fi
 
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then
-  if [[ "${CI:-}" == "true" || -n "${GITHUB_ACTIONS:-}" ]]; then
-    echo "Running on protected branch in CI context: $branch"
+  if in_ci; then
+    echo "Protected branch $branch in a CI checkout; not local work."
+    exit 0
+  fi
+  # A verification run against a clean checkout of the default branch is not
+  # somebody editing main. At commit time something is always staged, so this
+  # cannot excuse a real commit.
+  if [[ -z "$(git status --porcelain)" ]]; then
+    echo "Clean $branch checkout; no direct work detected."
     exit 0
   fi
   echo "Direct work on $branch is blocked."
   exit 1
 fi
 
+# Automation names its own branches and cannot rename them to fit a convention.
 if [[ "$branch" == dependabot/* ]]; then
-  if [[ "${CI:-}" == "true" || -n "${GITHUB_ACTIONS:-}" ]]; then
-    echo "Running on Dependabot branch in CI context: $branch"
-    exit 0
-  fi
+  echo "Dependabot automation branch; skipping branch-name enforcement."
+  exit 0
 fi
 
-if ! [[ "$branch" =~ $pattern ]]; then
+if [[ "$branch" == release-please--branches--* ]]; then
+  echo "Release Please automation branch; skipping branch-name enforcement."
+  exit 0
+fi
+
+if ! [[ "$branch" =~ $typed_pattern || "$branch" =~ $peer_pattern ]]; then
   echo "Invalid branch: $branch"
-  echo "Expected: <type>/<slug> or codex/<type>/<slug>"
+  echo "Expected: <type>/<slug>, codex/<type>/<slug>, or <agent>/<task-slug>"
   exit 1
 fi

--- a/scripts/git/guard-generated.sh
+++ b/scripts/git/guard-generated.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 # codex-os-managed
 forbidden='(^|/)(node_modules|dist|build|out|coverage|\.next|target)/'
-if git diff --cached --name-only | grep -E "$forbidden" >/dev/null; then
+# --diff-filter=d excludes deletions. Without it, staging the removal of build
+# output that was committed by mistake trips this guard, so the only way to act
+# on the message below is to bypass the hook that prints it.
+if git diff --cached --name-only --diff-filter=d | grep -E "$forbidden" >/dev/null; then
   echo "Generated artifacts are staged. Unstage them before commit."
   exit 1
 fi

--- a/scripts/git/guard-large-files.sh
+++ b/scripts/git/guard-large-files.sh
@@ -4,12 +4,16 @@ set -euo pipefail
 # codex-os-managed
 max_bytes="${GIT_GUARD_MAX_BYTES:-2097152}"
 fail=0
-while IFS= read -r file; do
-  [[ -f "$file" ]] || continue
-  size=$(wc -c <"$file")
+# -z emits NUL-separated paths verbatim. Without it git renders any path that
+# is not plain ASCII in quoted escaped form, so a file named "café.txt" comes
+# back as "caf\303\251.txt" and the cat-file lookup below fails with a fatal
+# error. Under set -e that aborts the guard, and the commit is refused with a
+# message about a path not existing rather than anything about file size.
+while IFS= read -r -d '' file; do
+  size=$(git cat-file -s ":$file")
   if (( size > max_bytes )); then
     echo "Large file staged (>${max_bytes} bytes): $file"
     fail=1
   fi
-done < <(git diff --cached --name-only --diff-filter=AM)
+done < <(git diff --cached --name-only -z --diff-filter=AM)
 exit $fail

--- a/scripts/git/guard-no-main-push.sh
+++ b/scripts/git/guard-no-main-push.sh
@@ -7,3 +7,23 @@ if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   echo "Pushing from $branch is blocked."
   exit 1
 fi
+
+# The check above only knows which branch you are standing on. It does not see
+# where the push is going, so `git push origin feature:main` passes it while
+# writing straight to the protected branch. Git hands a pre-push hook one line
+# per ref on stdin, "<local ref> <local sha> <remote ref> <remote sha>", which
+# is the only place the destination appears. Read it and refuse by destination.
+#
+# Skip the read entirely on a terminal. Run by hand as
+# `pnpm git:guard:no-main-push`, an unguarded read would sit waiting for input
+# that never comes, turning a guard into a hang. Outside a pre-push hook the
+# branch check above is the whole guard, which is the pre-existing behaviour.
+if [[ ! -t 0 ]]; then
+  while IFS=' ' read -r _local_ref _local_sha remote_ref _remote_sha; do
+    [[ -z "$remote_ref" ]] && continue
+    if [[ "$remote_ref" =~ ^refs/heads/(main|master)$ ]]; then
+      echo "Push to protected branch (${remote_ref#refs/heads/}) is blocked."
+      exit 1
+    fi
+  done
+fi

--- a/scripts/git/guard-secrets.sh
+++ b/scripts/git/guard-secrets.sh
@@ -3,6 +3,28 @@ set -euo pipefail
 
 # codex-os-managed
 if ! command -v gitleaks >/dev/null 2>&1; then
+  # Three repositories reach this branch for real: their CI runs this guard
+  # through the verify bundle on a runner that never installs gitleaks, so
+  # refusing here would fail every pull request without scanning anything.
+  # Everywhere else the bundle is CI-gated or its calling workflow never runs,
+  # so this branch costs nothing. Both variable spellings are accepted because
+  # different repos in the portfolio checked different ones.
+  #
+  # The value is checked, not merely the variable's presence. Every system that
+  # reaches this branch for real sets exactly "true" (GitHub Actions, and GitLab
+  # for the one repo that has a pipeline). Testing presence instead would let
+  # CI=false, or a developer who exports CI for unrelated tooling, silently turn
+  # off the only secret check a local commit gets.
+  if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "gitleaks not found in this CI job; skipping the local secret guard."
+    # Deliberately not claiming CI scanning covers this. In much of the
+    # portfolio the gitleaks workflow triggers on pull_request only, so a
+    # direct push to the default branch is scanned by nothing at all.
+    echo "Secret scanning in CI belongs to the git-hygiene workflow; confirm it runs on this event."
+    exit 0
+  fi
+  # Outside CI, refuse. A missing scanner is not a clean scan, and this hook is
+  # the only secret check a commit reaches when it never becomes a pull request.
   echo "gitleaks not found. Install gitleaks to enforce secret scanning."
   exit 1
 fi

--- a/scripts/git/propose-commit-message.mjs
+++ b/scripts/git/propose-commit-message.mjs
@@ -1,5 +1,15 @@
+// Promoted from AssistSupport, which was the only repository whose version
+// derived a real scope from the staged paths and named the file it changed,
+// instead of always proposing "update N files" against a guessed scope.
+//
+// Kept from the majority version: the output path, which 49 repositories use.
+// Nothing anywhere reads either file, so the name is free, and churn is not.
 import { execFileSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+const SUBJECT_LIMIT = 72;
+const OUT = ".git/CODEX_COMMIT_MSG_PROPOSAL";
 
 const staged = execFileSync(
   "/usr/bin/git",
@@ -16,26 +26,61 @@ if (staged.length === 0) {
 }
 
 const lower = staged.map((f) => f.toLowerCase());
-const hasDocs = lower.some((f) => f.endsWith(".md") || f.includes("docs/"));
-const hasTests = lower.some((f) => f.includes("test") || f.includes("spec"));
+
+// The most common top-level directory, which is a scope the reader can act on.
+// A file at the repository root has no directory to name, and using its
+// filename would produce chore(package.json): update package.json, so those
+// count as "repo". A leading dot is dropped so .github reads as github.
+const counts = new Map();
+for (const file of staged) {
+  const top = file.includes("/") ? file.split("/")[0] : "repo";
+  counts.set(top, (counts.get(top) ?? 0) + 1);
+}
+const scope = [...counts.entries()]
+  .sort((a, b) => b[1] - a[1])[0][0]
+  .toLowerCase()
+  .replace(/^\.+/, "");
+
+// every, not some: staging one Markdown file alongside source is a source
+// change with a note attached, not a docs change.
+const allDocs = lower.every((f) => f.endsWith(".md"));
+// Anchored on path segments and filename markers. Matching the bare substring
+// "test" also matches latest.ts and contest.js.
+const hasTests = lower.some(
+  (f) => f.includes("/tests/") || f.includes(".test.") || f.includes(".spec."),
+);
 const hasCi = lower.some((f) => f.startsWith(".github/workflows/"));
-const hasPerf = lower.some((f) => f.includes("/perf/") || f.includes("lighthouserc"));
-const hasDeps = lower.some((f) => f.endsWith("package.json") || f.includes("lock"));
+const hasPerf = lower.some(
+  (f) => f.includes("/perf/") || f.includes("lighthouserc"),
+);
+// Named explicitly rather than matching "lock" anywhere, which also matches
+// blocklist.ts, while still covering the ecosystems this portfolio uses.
+const LOCKFILES = [
+  "package.json",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "cargo.toml",
+  "cargo.lock",
+  "uv.lock",
+  "poetry.lock",
+];
+const hasDeps = lower.some((f) => LOCKFILES.includes(path.basename(f)));
 
 let type = "feat";
-if (hasCi) type = "ci";
+if (allDocs) type = "docs";
+else if (hasCi) type = "ci";
 else if (hasPerf) type = "perf";
 else if (hasTests) type = "test";
-else if (hasDocs) type = "docs";
-else if (hasDeps) type = "build";
+else if (hasDeps) type = "chore";
 
-let scope = "repo";
-if (lower.some((f) => f.includes("scripts/git/"))) scope = "git";
-else if (lower.some((f) => f.includes("scripts/perf/"))) scope = "perf";
-else if (lower.some((f) => f.startsWith(".github/"))) scope = "ci";
+const focus =
+  staged.length === 1
+    ? `update ${path.basename(staged[0])}`
+    : `update ${staged.length} files for ${scope} changes`;
 
-const summary = `${type}(${scope}): update ${staged.length} file${staged.length === 1 ? "" : "s"}`;
-const out = `.git/CODEX_COMMIT_MSG_PROPOSAL`;
-writeFileSync(out, `${summary}\n`);
+const summary = `${type}(${scope}): ${focus}`.slice(0, SUBJECT_LIMIT);
+
+writeFileSync(OUT, `${summary}\n`);
 console.log(summary);
-console.log(`written: ${out}`);
+console.log(`written: ${OUT}`);

--- a/scripts/git/session-resume.sh
+++ b/scripts/git/session-resume.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 
 # codex-os-managed
-if [[ ! -f .git/CODEX_LAST_WIP ]]; then
+marker_path="$(git rev-parse --git-path CODEX_LAST_WIP)"
+if [[ ! -f "$marker_path" ]]; then
   echo "No saved WIP tag found."
   exit 1
 fi
 
-tag="$(cat .git/CODEX_LAST_WIP)"
+tag="$(cat "$marker_path")"
 git stash list | grep -F "$tag" >/dev/null
 git stash apply "stash^{/$tag}"
 echo "Restored WIP: $tag"

--- a/scripts/git/session-save.sh
+++ b/scripts/git/session-save.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # codex-os-managed
 tag="codex-wip/$(git rev-parse --abbrev-ref HEAD)/$(date +%Y%m%d-%H%M%S)"
+marker_path="$(git rev-parse --git-path CODEX_LAST_WIP)"
 git stash push -u -m "$tag"
-echo "$tag" > .git/CODEX_LAST_WIP
+echo "$tag" > "$marker_path"
 echo "Saved WIP: $tag"

--- a/scripts/git/tests/test-create-branch.sh
+++ b/scripts/git/tests/test-create-branch.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression test for create-branch.sh.
+#
+# Pins validation, the bounded slug, branch reuse, and base resolution. The base
+# matters most: the version this was promoted from hardcoded origin/master,
+# which is correct in one repository and wrong in most of the portfolio.
+#
+# Usage: bash scripts/git/tests/test-create-branch.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/create-branch.sh"
+failures=0
+
+report() {
+  local name="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-46s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-46s want=%s got=%s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+# A repo whose default branch is named by the caller, so the master-vs-main
+# question is exercised rather than assumed.
+seed() {
+  local tmp="$1" default="${2:-main}"
+  git init -b "$default" "$tmp" >/dev/null 2>&1
+  git -C "$tmp" config user.email t@example.com
+  git -C "$tmp" config user.name T
+  echo seed > "$tmp/README.md"
+  git -C "$tmp" add README.md >/dev/null
+  git -C "$tmp" commit -m seed >/dev/null
+}
+
+# Returns the branch actually checked out, or rc=<code> when the script refused.
+landed() {
+  local tmp="$1"; shift
+  if (cd "$tmp" && bash "$SCRIPT" "$@" >/dev/null 2>&1); then
+    git -C "$tmp" rev-parse --abbrev-ref HEAD
+  else
+    echo "rc=$?"
+  fi
+}
+
+echo "create-branch regression tests"
+
+tmp="$(mktemp -d)"; seed "$tmp"
+report "a task becomes a slugged branch" "codex/feat/add-user-login" \
+  "$(landed "$tmp" "Add User Login")"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"
+report "the type is honoured" "codex/fix/null-pointer" \
+  "$(landed "$tmp" "Null pointer" fix)"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"
+report "an invalid type is refused" "rc=1" \
+  "$(landed "$tmp" "Some task" banana)"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"
+report "an empty task is refused" "rc=1" "$(landed "$tmp" "")"
+rm -rf "$tmp"
+
+# Punctuation-only input slugs to nothing. Without a check the branch would be
+# codex/feat/ , which git refuses with a less obvious error.
+tmp="$(mktemp -d)"; seed "$tmp"
+report "a task that slugs to nothing is refused" "rc=1" \
+  "$(landed "$tmp" "!!! ???")"
+rm -rf "$tmp"
+
+# A branch name is a path component, so an unbounded slug fails at checkout
+# rather than at validation.
+tmp="$(mktemp -d)"; seed "$tmp"
+long="$(landed "$tmp" "$(printf 'averylongword %.0s' {1..20})")"
+report "a long task still lands on a branch" "codex/feat" "${long%/*}"
+# codex/feat/ is 11 characters, so the rest is the slug.
+report "its slug is capped at 48 characters" "48" "$((${#long} - 11))"
+rm -rf "$tmp"
+
+# Resuming a task must not be a fatal error.
+tmp="$(mktemp -d)"; seed "$tmp"
+landed "$tmp" "Reuse me" >/dev/null
+git -C "$tmp" checkout --quiet main
+report "an existing branch is resumed, not refused" "codex/feat/reuse-me" \
+  "$(landed "$tmp" "Reuse me")"
+rm -rf "$tmp"
+
+# Base resolution, both spellings. Hardcoding either name breaks half of these.
+tmp="$(mktemp -d)"; seed "$tmp" main
+report "branches from main when that is the default" "codex/feat/from-default" \
+  "$(landed "$tmp" "From default")"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp" master
+report "branches from master when that is the default" "codex/feat/from-default" \
+  "$(landed "$tmp" "From default")"
+rm -rf "$tmp"
+
+# An explicit base wins over resolution.
+tmp="$(mktemp -d)"; seed "$tmp" main
+git -C "$tmp" branch other >/dev/null
+report "an explicit base is used" "codex/chore/explicit-base" \
+  "$(landed "$tmp" "Explicit base" chore other)"
+rm -rf "$tmp"
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"

--- a/scripts/git/tests/test-guard-atomic.sh
+++ b/scripts/git/tests/test-guard-atomic.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Regression test for guard-atomic.sh.
+#
+# Pins the limit, that deletions count toward it, and the intentional-exception
+# escape hatch that was promoted here from AssistSupport.
+#
+# Usage: bash scripts/git/tests/test-guard-atomic.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/guard-atomic.sh"
+failures=0
+
+seed() {
+  local tmp="$1"
+  git init -b main "$tmp" >/dev/null 2>&1
+  git -C "$tmp" config user.email t@example.com
+  git -C "$tmp" config user.name T
+  echo seed > "$tmp/README.md"
+  git -C "$tmp" add README.md >/dev/null
+  git -C "$tmp" commit -m seed >/dev/null
+}
+
+report() {
+  local name="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-46s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-46s want=%s got=%s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+verdict() { if bash "$GUARD" >/dev/null 2>&1; then echo allowed; else echo REFUSED; fi; }
+
+stage_files() {
+  local tmp="$1" n="$2" i
+  for ((i = 0; i < n; i++)); do echo x > "$tmp/f$i.txt"; done
+  git -C "$tmp" add -A >/dev/null
+}
+
+echo "guard-atomic regression tests"
+
+tmp="$(mktemp -d)"; seed "$tmp"; stage_files "$tmp" 10
+report "10 staged files are allowed" allowed "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"; stage_files "$tmp" 25
+report "exactly the limit is allowed" allowed "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"; stage_files "$tmp" 26
+report "one over the limit is refused" REFUSED "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"
+report "nothing staged is allowed" allowed "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"; stage_files "$tmp" 40
+report "a raised limit is honoured" allowed \
+  "$(cd "$tmp" && GIT_GUARD_MAX_FILES=50 verdict)"
+rm -rf "$tmp"
+
+# The escape hatch is the whole point of this promotion: without it the only
+# way past the guard is to bypass the hook, which disables four other guards.
+tmp="$(mktemp -d)"; seed "$tmp"; stage_files "$tmp" 40
+report "the escape hatch allows a large commit" allowed \
+  "$(cd "$tmp" && GIT_GUARD_ALLOW_LARGE_COMMIT=1 verdict)"
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"; seed "$tmp"; stage_files "$tmp" 40
+report "any other hatch value does not excuse it" REFUSED \
+  "$(cd "$tmp" && GIT_GUARD_ALLOW_LARGE_COMMIT=0 verdict)"
+rm -rf "$tmp"
+
+# Deletions count. Removing forty files is a large commit in either direction,
+# and the hatch above is how to say it was deliberate.
+tmp="$(mktemp -d)"; seed "$tmp"; stage_files "$tmp" 40
+git -C "$tmp" commit -m bulk >/dev/null
+(cd "$tmp" && rm -f f*.txt)
+git -C "$tmp" add -A >/dev/null
+report "40 staged deletions are refused" REFUSED "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"

--- a/scripts/git/tests/test-guard-branch.sh
+++ b/scripts/git/tests/test-guard-branch.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Regression test for guard-branch.sh.
+#
+# This guard had drifted into ten variants across the portfolio, each repo
+# solving a different real problem locally. The consolidated version accepts
+# every shape those variants accepted; this pins each one so the next
+# divergence fails here instead of in fifty working copies.
+#
+# Usage: bash scripts/git/tests/test-guard-branch.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/guard-branch.sh"
+failures=0
+
+report() {
+  local name="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-44s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-44s want=%s got=%s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+# run <branch|--detached> [--dirty] [ENV=VAL ...]
+run_guard() {
+  local branch="$1"; shift
+  local dirty=false
+  if [[ "${1:-}" == "--dirty" ]]; then dirty=true; shift; fi
+
+  local tmp rc
+  tmp="$(mktemp -d)"
+  (
+    cd "$tmp" || exit 1
+    git init -b main . >/dev/null 2>&1
+    git config user.email t@example.com
+    git config user.name T
+    echo seed > README.md
+    git add README.md >/dev/null
+    git commit -m seed >/dev/null
+
+    if [[ "$branch" == "--detached" ]]; then
+      git checkout --detach >/dev/null 2>&1
+    elif [[ "$branch" != "main" ]]; then
+      # A name git refuses leaves the checkout on main, and the case then
+      # quietly tests the default branch instead of what it claims to. Exit 99
+      # so that shows up as a failure rather than a pass.
+      git checkout -b "$branch" >/dev/null 2>&1 || exit 99
+      [[ "$(git rev-parse --abbrev-ref HEAD)" == "$branch" ]] || exit 99
+    fi
+
+    if $dirty; then
+      echo change >> README.md
+      git add README.md >/dev/null
+    fi
+
+    # CI variables are only honoured when the guard believes it is in CI, so
+    # each case passes exactly the environment it means to test.
+    env -u CI -u GITHUB_ACTIONS -u GITHUB_HEAD_REF -u GITHUB_REF_NAME \
+        -u GITHUB_REF_TYPE "$@" bash "$GUARD" >/dev/null 2>&1
+  )
+  rc=$?
+  rm -rf "$tmp"
+  return $rc
+}
+
+check() {
+  local name="$1" want="$2"; shift 2
+  local got
+  if run_guard "$@"; then got=allowed; else got=REFUSED; fi
+  report "$name" "$want" "$got"
+}
+
+echo "guard-branch regression tests"
+
+echo "  -- accepted shapes --"
+check "codex/<type>/<slug>"          allowed codex/fix/null-pointer
+check "<type>/<slug>, no prefix"     allowed fix/null-pointer
+check "peer agent cc/<task-slug>"    allowed cc/rebuild-index
+check "peer agent codex/<task-slug>" allowed codex/rebuild-index
+
+echo "  -- rejected shapes --"
+check "unknown type"                 REFUSED feature/some-thing
+check "uppercase in slug"            REFUSED codex/feat/BadSlug
+check "bare word, no slash"          REFUSED wip
+check "underscore in slug"           REFUSED codex/fix/has_underscore
+check "unknown type under codex/"    REFUSED codex/badtype/slug
+check "peer name without a hyphen"   REFUSED cc/single
+
+echo "  -- the default branch --"
+check "main with staged work"        REFUSED main --dirty
+check "main clean is a verify run"   allowed main
+check "main inside CI"               allowed main --dirty CI=true
+check "main inside GitHub Actions"   allowed main --dirty GITHUB_ACTIONS=true
+
+echo "  -- automation branches --"
+check "dependabot branch"            allowed dependabot/npm_and_yarn/left-pad-1.2.3
+check "dependabot branch in CI"      allowed dependabot/npm_and_yarn/left-pad-1.2.3 CI=true
+check "release-please branch"        allowed release-please--branches--main
+
+echo "  -- detached HEAD --"
+check "detached locally is refused"  REFUSED --detached
+check "detached in CI is skipped"    allowed --detached CI=true
+
+echo "  -- CI resolves the name from the event --"
+check "valid GITHUB_HEAD_REF"        allowed --detached CI=true GITHUB_HEAD_REF=codex/fix/from-event
+check "invalid GITHUB_HEAD_REF"      REFUSED --detached CI=true GITHUB_HEAD_REF=feature/from-event
+check "valid GITHUB_REF_NAME"        allowed --detached CI=true GITHUB_REF_NAME=fix/from-ref
+check "a tag ref is not a branch"    allowed --detached CI=true GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.2.3
+check "env is ignored outside CI"    REFUSED --detached GITHUB_HEAD_REF=codex/fix/from-event
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"

--- a/scripts/git/tests/test-guard-generated.sh
+++ b/scripts/git/tests/test-guard-generated.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression test for guard-generated.sh.
+#
+# The guard refuses staged build output. It must not refuse the removal of
+# build output that was committed by mistake, which is the one action its own
+# error message asks for.
+#
+# Usage: bash scripts/git/tests/test-guard-generated.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/guard-generated.sh"
+failures=0
+
+# A global ignore file commonly lists dist/, so every add here uses -f. Without
+# it the add silently stages nothing and the guard looks like it passed.
+seed() {
+  local tmp="$1"
+  git init -b main "$tmp" >/dev/null 2>&1
+  git -C "$tmp" config user.email t@example.com
+  git -C "$tmp" config user.name T
+  echo seed > "$tmp/README.md"
+  git -C "$tmp" add README.md >/dev/null
+  git -C "$tmp" commit -m seed >/dev/null
+}
+
+report() {
+  local name="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-46s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-46s want=%s got=%s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+verdict() { if bash "$GUARD" >/dev/null 2>&1; then echo allowed; else echo REFUSED; fi; }
+
+echo "guard-generated regression tests"
+
+# staging build output is refused
+tmp="$(mktemp -d)"; seed "$tmp"
+mkdir -p "$tmp/dist"; echo built > "$tmp/dist/app.js"
+git -C "$tmp" add -f dist/app.js >/dev/null
+report "staging dist/ is refused" REFUSED "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+# ordinary source is untouched
+tmp="$(mktemp -d)"; seed "$tmp"
+echo source > "$tmp/src.js"
+git -C "$tmp" add src.js >/dev/null
+report "ordinary source is allowed" allowed "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+# removing previously committed build output must be allowed
+tmp="$(mktemp -d)"; seed "$tmp"
+mkdir -p "$tmp/dist"; echo built > "$tmp/dist/app.js"
+git -C "$tmp" add -f dist/app.js >/dev/null
+git -C "$tmp" commit -m "committed build output by mistake" >/dev/null
+git -C "$tmp" rm -r --cached dist >/dev/null
+report "removing committed dist/ is allowed" allowed "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+# a modification to build output still counts as staging it
+tmp="$(mktemp -d)"; seed "$tmp"
+mkdir -p "$tmp/dist"; echo built > "$tmp/dist/app.js"
+git -C "$tmp" add -f dist/app.js >/dev/null
+git -C "$tmp" commit -m "build output" >/dev/null
+echo rebuilt > "$tmp/dist/app.js"
+git -C "$tmp" add -f dist/app.js >/dev/null
+report "modifying tracked dist/ is refused" REFUSED "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"

--- a/scripts/git/tests/test-guard-large-files.sh
+++ b/scripts/git/tests/test-guard-large-files.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regression test for guard-large-files.sh.
+#
+# Size is the easy half. The half that broke is path handling: git renders any
+# path outside plain ASCII in quoted escaped form unless asked not to, and the
+# guard then looked up a filename that does not exist.
+#
+# Usage: bash scripts/git/tests/test-guard-large-files.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/guard-large-files.sh"
+failures=0
+
+seed() {
+  local tmp="$1"
+  git init -b main "$tmp" >/dev/null 2>&1
+  git -C "$tmp" config user.email t@example.com
+  git -C "$tmp" config user.name T
+}
+
+report() {
+  local name="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-46s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-46s want=%s got=%s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+verdict() { if bash "$GUARD" >/dev/null 2>&1; then echo allowed; else echo REFUSED; fi; }
+
+# stage_one <filename> ; creates a 5-byte file with that exact name
+small_case() {
+  local name="$1" label="$2" want="$3"
+  local tmp; tmp="$(mktemp -d)"
+  seed "$tmp"
+  printf 'tiny\n' > "$tmp/$name"
+  git -C "$tmp" add -- "$name" >/dev/null 2>&1
+  report "$label" "$want" "$(cd "$tmp" && verdict)"
+  rm -rf "$tmp"
+}
+
+echo "guard-large-files regression tests"
+
+# oversized content is refused
+tmp="$(mktemp -d)"; seed "$tmp"
+: > "$tmp/blob.bin"
+dd if=/dev/zero of="$tmp/blob.bin" bs=1048576 count=3 >/dev/null 2>&1
+git -C "$tmp" add blob.bin >/dev/null
+report "3MB file is refused" REFUSED "$(cd "$tmp" && verdict)"
+rm -rf "$tmp"
+
+# small files pass regardless of how awkward the name is
+small_case "small.txt"               "small ascii name is allowed"      allowed
+small_case "a file with spaces.txt"  "name with spaces is allowed"      allowed
+small_case "café-notes.txt"          "non-ascii name is allowed"        allowed
+small_case "naïve—dash.txt"          "multibyte punctuation is allowed" allowed
+
+# the limit is configurable and still enforced on an awkward name
+tmp="$(mktemp -d)"; seed "$tmp"
+printf 'aaaaaaaaaaaaaaaaaaaa\n' > "$tmp/café-big.txt"
+git -C "$tmp" add -- "café-big.txt" >/dev/null
+if (cd "$tmp" && GIT_GUARD_MAX_BYTES=5 bash "$GUARD" >/dev/null 2>&1); then
+  got=allowed
+else
+  got=REFUSED
+fi
+report "non-ascii name over the limit is refused" REFUSED "$got"
+rm -rf "$tmp"
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"

--- a/scripts/git/tests/test-guard-no-main-push.sh
+++ b/scripts/git/tests/test-guard-no-main-push.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Regression test for guard-no-main-push.sh.
+#
+# The guard originally checked only which branch you were standing on, so
+# `git push origin feature:main` passed it while writing straight to the
+# protected branch. This drives real pushes through a throwaway repo to prove
+# the destination is now what gets refused.
+#
+# Usage: bash scripts/git/tests/test-guard-no-main-push.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/guard-no-main-push.sh"
+failures=0
+
+# Build a bare "origin" plus a clone whose pre-push hook is the guard, with a
+# feature branch checked out and one commit ahead.
+build() {
+  local tmp="$1"
+  git init --bare -b main "$tmp/origin.git" >/dev/null 2>&1
+  git clone "$tmp/origin.git" "$tmp/work" >/dev/null 2>&1
+
+  git -C "$tmp/work" config user.email t@example.com
+  git -C "$tmp/work" config user.name T
+
+  echo seed > "$tmp/work/README.md"
+  git -C "$tmp/work" add README.md >/dev/null
+  git -C "$tmp/work" commit -m seed >/dev/null
+  git -C "$tmp/work" push origin main >/dev/null 2>&1
+
+  # husky invokes the guard through a wrapper; stdin must pass straight through
+  printf '#!/usr/bin/env bash\nexec bash %q "$@"\n' "$GUARD" \
+    > "$tmp/work/.git/hooks/pre-push"
+  chmod +x "$tmp/work/.git/hooks/pre-push"
+
+  git -C "$tmp/work" checkout -b feature >/dev/null 2>&1
+  echo x > "$tmp/work/f.txt"
+  git -C "$tmp/work" add f.txt >/dev/null
+  git -C "$tmp/work" commit -m feat >/dev/null
+}
+
+# check <name> <expected BLOCK|ALLOW> <checkout-first> <push args...>
+check() {
+  local name="$1" want="$2" checkout="$3"; shift 3
+  local tmp got
+  tmp="$(mktemp -d)"
+  build "$tmp"
+  [[ -n "$checkout" ]] && git -C "$tmp/work" checkout "$checkout" >/dev/null 2>&1
+
+  if git -C "$tmp/work" push "$@" >/dev/null 2>&1; then got=ALLOW; else got=BLOCK; fi
+  rm -rf "$tmp"
+
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-38s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-38s want=%s got=%s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "guard-no-main-push regression tests"
+check "feature -> main is refused"    BLOCK ""     origin feature:main
+check "feature -> feature is allowed" ALLOW ""     origin feature:feature
+check "pushing while on main refused" BLOCK main   origin main
+
+# Run by hand with no push payload the guard must exit cleanly rather than
+# block on a read that never receives input.
+#
+# This runs inside a throwaway repo on a feature branch, never in this
+# checkout. Run here it would inherit whatever branch the checkout is on, and
+# on main the guard correctly refuses, so the case would fail on main and pass
+# everywhere else. That is a property of the checkout, not of the guard.
+hand_run() {
+  local branch="$1" tmp rc
+  tmp="$(mktemp -d)"
+  build "$tmp"
+  git -C "$tmp/work" checkout "$branch" >/dev/null 2>&1
+  ( cd "$tmp/work" && timeout 10 bash "$GUARD" < /dev/null >/dev/null 2>&1 )
+  rc=$?
+  rm -rf "$tmp"
+  return $rc
+}
+
+if hand_run feature; then
+  printf '  PASS  %-38s (exit 0)\n' "hand-run on a feature branch"
+else
+  printf '  FAIL  %-38s hung or exited non-zero\n' "hand-run on a feature branch"
+  failures=$((failures + 1))
+fi
+
+# Standing on main with no push payload, the original branch check still fires.
+if hand_run main; then
+  printf '  FAIL  %-38s want refusal, got exit 0\n' "hand-run while on main"
+  failures=$((failures + 1))
+else
+  printf '  PASS  %-38s (refused)\n' "hand-run while on main"
+fi
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"

--- a/scripts/git/tests/test-guard-secrets.sh
+++ b/scripts/git/tests/test-guard-secrets.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Regression test for guard-secrets.sh.
+#
+# The guard's own logic is what varies between repos, so that is what this
+# pins: whether a finding is refused, whether a clean scan passes, and what
+# happens when the scanner is missing inside and outside CI.
+#
+# gitleaks is replaced by a stub whose exit code the test controls. That keeps
+# the suite hermetic, independent of which gitleaks version is installed and
+# of its rule set, and means no credential-shaped string needs to exist in
+# this repository to test a secret scanner.
+#
+# Usage: bash scripts/git/tests/test-guard-secrets.sh
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")/.." && pwd)/guard-secrets.sh"
+failures=0
+
+report() {
+  local name="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-46s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-46s want=%s got=%s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+# run_guard <stub-exit|none> [ENV=VAL ...]
+# stub-exit "none" removes gitleaks from PATH entirely.
+run_guard() {
+  local stub="$1"; shift
+  local tmp rc
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/bin" "$tmp/repo"
+
+  if [[ "$stub" != "none" ]]; then
+    printf '#!/usr/bin/env bash\nexit %s\n' "$stub" > "$tmp/bin/gitleaks"
+    chmod +x "$tmp/bin/gitleaks"
+  fi
+
+  (
+    cd "$tmp/repo" || exit 1
+    git init -b main . >/dev/null 2>&1
+    git config user.email t@example.com
+    git config user.name T
+    echo content > file.txt
+    git add file.txt >/dev/null
+
+    env -u CI -u GITHUB_ACTIONS "PATH=$tmp/bin:/usr/bin:/bin" "$@" \
+        bash "$GUARD" >/dev/null 2>&1
+  )
+  rc=$?
+  rm -rf "$tmp"
+  return $rc
+}
+
+check() {
+  local name="$1" want="$2"; shift 2
+  local got
+  if run_guard "$@"; then got=allowed; else got=REFUSED; fi
+  report "$name" "$want" "$got"
+}
+
+echo "guard-secrets regression tests"
+
+echo "  -- with a scanner present --"
+check "a finding is refused"                  REFUSED 1
+check "a clean scan is allowed"               allowed 0
+
+echo "  -- with no scanner --"
+check "outside CI it fails closed"            REFUSED none
+check "CI=true skips"                         allowed none CI=true
+check "GITHUB_ACTIONS=true skips"             allowed none GITHUB_ACTIONS=true
+
+# The escape hatch keys on the exact value "true", not on the variable merely
+# being set. Every system that reaches this branch for real (GitHub Actions,
+# GitLab CI) sets exactly "true", while a developer who exports CI for unrelated
+# tooling, or anything that sets it to a falsey string, would otherwise turn the
+# only local secret check off without meaning to.
+echo "  -- the escape hatch needs the value, not just the variable --"
+check "CI=1 does not skip"                    REFUSED none CI=1
+check "CI=false does not skip"                REFUSED none CI=false
+check "GITHUB_ACTIONS=false does not skip"    REFUSED none GITHUB_ACTIONS=false
+
+echo "  -- the scanner still decides inside CI --"
+check "finding in CI is still refused"        REFUSED 1 CI=true
+check "clean scan in CI is allowed"           allowed 0 CI=true
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"

--- a/scripts/git/tests/test-propose-commit-message.sh
+++ b/scripts/git/tests/test-propose-commit-message.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regression test for propose-commit-message.mjs.
+#
+# The proposal is advisory, so nothing breaks when it is wrong. What it costs is
+# trust: a proposer that calls a source change "docs" gets ignored, and then it
+# may as well not exist. These cases pin the classifications that were wrong
+# before this script was promoted.
+#
+# Usage: bash scripts/git/tests/test-propose-commit-message.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/propose-commit-message.mjs"
+failures=0
+
+report() {
+  local name="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    printf '  PASS  %-46s (%s)\n' "$name" "$got"
+  else
+    printf '  FAIL  %-46s\n        want: %s\n        got:  %s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+  fi
+}
+
+# propose <expected> <name> <path>...
+propose() {
+  local want="$1" name="$2"; shift 2
+  local tmp got
+  tmp="$(mktemp -d)"
+  git init -b main "$tmp" >/dev/null 2>&1
+  git -C "$tmp" config user.email t@example.com
+  git -C "$tmp" config user.name T
+  local p
+  for p in "$@"; do
+    mkdir -p "$tmp/$(dirname "$p")"
+    echo x > "$tmp/$p"
+    git -C "$tmp" add -f -- "$p" >/dev/null 2>&1
+  done
+  got="$(cd "$tmp" && node "$SCRIPT" 2>/dev/null | head -1)"
+  [[ -n "$got" ]] || got="(no output)"
+  report "$name" "$want" "$got"
+  rm -rf "$tmp"
+}
+
+echo "propose-commit-message regression tests"
+
+echo "  -- scope comes from the staged paths --"
+propose "feat(src): update app.ts"            "a single source file is named"      src/app.ts
+propose "feat(src): update 2 files for src changes" "several files report their scope" src/a.ts src/b.ts
+propose "ci(github): update ci.yml"           "a leading dot is dropped from scope" .github/workflows/ci.yml
+
+echo "  -- classification --"
+propose "docs(docs): update guide.md"         "docs only is docs"                  docs/guide.md
+propose "test(tests): update unit.test.ts"    "a .test. file is a test change"     tests/unit.test.ts
+propose "perf(scripts): update bench.ts"      "a perf path is a perf change"       scripts/perf/bench.ts
+propose "chore(repo): update package.json"       "a manifest is a chore"              package.json
+propose "chore(repo): update Cargo.toml"         "a Rust manifest is a chore too"     Cargo.toml
+
+echo "  -- classifications that were wrong before --"
+# hasDocs used some(): one Markdown file alongside source made the whole commit
+# a docs change.
+propose "feat(src): update 2 files for src changes" \
+  "source plus a note is not a docs change" src/app.ts src/NOTES.md
+# hasTests matched the bare substring "test", so latest.ts was a test change.
+propose "feat(src): update latest.ts"         "latest.ts is not a test file"       src/latest.ts
+# hasDeps matched "lock" anywhere, so blocklist.ts was a dependency change.
+propose "feat(src): update blocklist.ts"      "blocklist.ts is not a lockfile"     src/blocklist.ts
+
+echo "  -- shape --"
+propose "(no output)"                          "nothing staged produces nothing"
+
+echo
+if (( failures )); then
+  echo "$failures failing"
+  exit 1
+fi
+echo "all passing"


### PR DESCRIPTION
Lands the consolidated `scripts/git` guard scripts, plus the eight test suites
that come with them, onto this repository's default branch.

These files had drifted into as many as ten versions across the portfolio. The
correct behaviour turned out to live in the rarest variant rather than in the
canonical copy, every time, so canonical was fixed first and this is the result
being propagated.

What changes behaviourally:

- `guard-no-main-push` reads the pre-push payload, so pushing the default branch
  from a feature branch is refused rather than silently allowed
- `guard-large-files` measures the staged blob, not the working tree, so a file
  staged large and shrunk afterwards no longer slips through
- `guard-generated` no longer refuses the removal of build output committed by
  mistake, which was the one action its own message asked for
- `guard-branch` accepts `<type>/<slug>`, `codex/<type>/<slug>` and peer-agent
  names, and exempts dependabot and release-please branches
- `guard-atomic` gains `GIT_GUARD_ALLOW_LARGE_COMMIT=1` for a deliberate exception
- `guard-secrets` keys its CI skip on `CI` being `"true"` rather than merely set,
  which closes three unintended bypasses
- `create-branch` validates the type, bounds the slug, and resumes an existing
  branch instead of failing
- `propose-commit-message` takes its scope from the staged paths

**Why this is a new branch.** The same commit was already applied a first time,
but onto whatever feature branch each repository happened to have checked out.
In eleven repositories that branch's pull request had merged weeks earlier, so
the commit landed on top of a closed pull request and could never reach the
default branch through it. It has been cherry-picked here onto a branch that
starts from the current default branch. The original commits were left where
they are; nothing was rewritten or force-pushed.

Verified: all eight guard suites pass in this repository, run against this
branch.
